### PR TITLE
HDDS-12613. Add GitHub Discussions question form to the website. 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -158,6 +158,10 @@ const config = {
                 label: 'Report An Issue',
               },
               {
+                to: 'community/ask-a-question',
+                label: 'Ask a Question',
+              },
+              {
                 to: 'community/how-to-contribute',
                 label: 'How to Contribute',
               },

--- a/src/components/AskQuestionForm/index.js
+++ b/src/components/AskQuestionForm/index.js
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from 'react';
+import styles from './styles.module.css';
+
+export default function AskQuestionForm() {
+  const [question, setQuestion] = useState('');
+  const [title, setTitle] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    
+    // Create the GitHub Discussions URL with query parameters
+    const baseUrl = 'https://github.com/apache/ozone/discussions/new';
+    const category = 'faq ';
+    const titleEncoded = encodeURIComponent(title);
+    const bodyEncoded = encodeURIComponent(question);
+    
+    const redirectUrl = `${baseUrl}?category=${category}&title=${titleEncoded}&body=${bodyEncoded}`;
+    
+    // Redirect to GitHub Discussions with the pre-filled question
+    window.location.href = redirectUrl;
+  };
+
+  return (
+    <div className={styles.formContainer}>
+      <h2 className={styles.formTitle}>Ask a Question</h2>
+      <p className={styles.formDescription}>Have a question about Apache Ozone? Fill out this form and we'll redirect you to GitHub Discussions with your question pre-filled.</p>
+      
+      <form onSubmit={handleSubmit} className={styles.form}>
+        <div className={styles.formGroup}>
+          <label htmlFor="title" className={styles.label}>Question Title:</label>
+          <input
+            type="text"
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Enter a title for your question"
+            required
+            className={styles.input}
+          />
+        </div>
+        
+        <div className={styles.formGroup}>
+          <label htmlFor="question" className={styles.label}>Your Question:</label>
+          <textarea
+            id="question"
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="Describe your question in detail..."
+            required
+            className={styles.textarea}
+            rows={5}
+          />
+        </div>
+        
+        <div className={styles.submitGroup}>
+          <button type="submit" className={styles.button}>
+            Submit to GitHub Discussions
+          </button>
+          <p className={styles.submitNote}>
+            Your question will be redirected to the official Apache Ozone GitHub Discussions board.
+            A GitHub account is required to participate.
+          </p>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/AskQuestionForm/styles.module.css
+++ b/src/components/AskQuestionForm/styles.module.css
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.formContainer {
+  max-width: 700px;
+  margin: 0 auto 40px;
+  padding: 30px;
+  background-color: var(--ifm-background-surface-color);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.formTitle {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.formDescription {
+  margin-bottom: 30px;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input,
+.textarea {
+  padding: 10px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+  font-size: 16px;
+  background-color: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.button {
+  padding: 12px 20px;
+  background-color: var(--ifm-color-primary);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  align-self: flex-start;
+}
+
+.button:hover {
+  background-color: var(--ifm-color-primary-darker);
+}
+
+.submitGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.submitNote {
+  font-size: 14px;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+  max-width: 500px;
+}
+
+@media (max-width: 768px) {
+  .formContainer {
+    padding: 15px;
+  }
+  
+  .button {
+    width: 100%;
+  }
+}

--- a/src/pages/community/ask-a-question.md
+++ b/src/pages/community/ask-a-question.md
@@ -1,0 +1,22 @@
+import AskQuestionForm from '@site/src/components/AskQuestionForm';
+
+# Ask a Question About Apache Ozone
+
+Have a question about Apache Ozone? Use the form below to submit your question to our GitHub Discussions. The form will redirect you to GitHub with your question pre-filled.
+
+<AskQuestionForm />
+
+<div style={{marginTop: '3rem'}}>
+
+## About GitHub Discussions
+
+</div>
+
+[GitHub Discussions](https://github.com/apache/ozone/discussions) is where our community comes together to ask and answer questions, share ideas, and discuss Apache Ozone. It's a great place to:
+
+- Get help with using Apache Ozone
+- Share your experiences with the community
+- Discuss ideas for improving Ozone
+- Connect with other Ozone users and contributors
+
+After submitting your question through this form, you'll be redirected to GitHub where you can track responses and engage with the community. You'll need a GitHub account to participate in discussions.

--- a/src/pages/community/ask-a-question.md
+++ b/src/pages/community/ask-a-question.md
@@ -1,16 +1,13 @@
-import AskQuestionForm from '@site/src/components/AskQuestionForm';
-
 # Ask a Question About Apache Ozone
+
+import AskQuestionForm from '@site/src/components/AskQuestionForm';
 
 Have a question about Apache Ozone? Use the form below to submit your question to our GitHub Discussions. The form will redirect you to GitHub with your question pre-filled.
 
+{/*We're using a special Docusaurus comment style to allow the React component*/}
 <AskQuestionForm />
 
-<div style={{marginTop: '3rem'}}>
-
 ## About GitHub Discussions
-
-</div>
 
 [GitHub Discussions](https://github.com/apache/ozone/discussions) is where our community comes together to ask and answer questions, share ideas, and discuss Apache Ozone. It's a great place to:
 

--- a/src/pages/community/ask-a-question.md
+++ b/src/pages/community/ask-a-question.md
@@ -1,11 +1,12 @@
 # Ask a Question About Apache Ozone
 
+<!-- markdownlint-disable -->
 import AskQuestionForm from '@site/src/components/AskQuestionForm';
 
 Have a question about Apache Ozone? Use the form below to submit your question to our GitHub Discussions. The form will redirect you to GitHub with your question pre-filled.
 
-{/*We're using a special Docusaurus comment style to allow the React component*/}
 <AskQuestionForm />
+<!-- markdownlint-enable -->
 
 ## About GitHub Discussions
 

--- a/src/pages/community/report-an-issue.md
+++ b/src/pages/community/report-an-issue.md
@@ -1,5 +1,32 @@
-# Report an Issue
+import AskQuestionForm from '@site/src/components/AskQuestionForm';
 
-**TODO [HDDS-9870](https://issues.apache.org/jira/browse/HDDS-9870) Fill in this page.**
+# Report an Issue or Ask a Question
 
-This can link to other relevant sections as necessary, like Jira account sign up in [Communication Channels](communication-channels). It should include best practices for filing detailed Jira descriptions, titles, and adding labels or other fields.
+## Have a Question?
+
+If you have a question about Apache Ozone, you can use the form below to submit it to our GitHub Discussions. This will redirect you to GitHub where you can continue the conversation with the community.
+
+<AskQuestionForm />
+
+<div style={{marginTop: '3rem'}}>
+
+## Report a Bug
+
+</div>
+
+If you've found a bug in Apache Ozone, please report it in our issue tracker. Before filing a new issue, please search for existing issues to avoid duplicates.
+
+1. Create a [Jira account](https://issues.apache.org/jira/secure/Signup!default.jspa) if you don't have one
+2. Go to the [Ozone Jira project](https://issues.apache.org/jira/projects/HDDS/issues)
+3. Click "Create" to report a new issue
+
+### Best Practices for Reporting Issues
+
+When creating a new issue, please include:
+
+- A clear, descriptive title
+- Detailed steps to reproduce the problem
+- Expected behavior vs. actual behavior
+- Version of Ozone you're using
+- Environment details (OS, Java version, etc.)
+- Any relevant logs or screenshots

--- a/src/pages/community/report-an-issue.md
+++ b/src/pages/community/report-an-issue.md
@@ -1,18 +1,15 @@
-import AskQuestionForm from '@site/src/components/AskQuestionForm';
-
 # Report an Issue or Ask a Question
+
+import AskQuestionForm from '@site/src/components/AskQuestionForm';
 
 ## Have a Question?
 
 If you have a question about Apache Ozone, you can use the form below to submit it to our GitHub Discussions. This will redirect you to GitHub where you can continue the conversation with the community.
 
+{/*We're using a special Docusaurus comment style to allow the React component*/}
 <AskQuestionForm />
 
-<div style={{marginTop: '3rem'}}>
-
 ## Report a Bug
-
-</div>
 
 If you've found a bug in Apache Ozone, please report it in our issue tracker. Before filing a new issue, please search for existing issues to avoid duplicates.
 

--- a/src/pages/community/report-an-issue.md
+++ b/src/pages/community/report-an-issue.md
@@ -1,5 +1,7 @@
 # Report an Issue or Ask a Question
 
+<!-- markdownlint-disable -->
+
 import AskQuestionForm from '@site/src/components/AskQuestionForm';
 
 ## Have a Question?
@@ -8,6 +10,8 @@ If you have a question about Apache Ozone, you can use the form below to submit 
 
 {/*We're using a special Docusaurus comment style to allow the React component*/}
 <AskQuestionForm />
+
+<!-- markdownlint-disable -->
 
 ## Report a Bug
 

--- a/src/pages/community/report-an-issue.md
+++ b/src/pages/community/report-an-issue.md
@@ -11,7 +11,7 @@ If you have a question about Apache Ozone, you can use the form below to submit 
 {/*We're using a special Docusaurus comment style to allow the React component*/}
 <AskQuestionForm />
 
-<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
 
 ## Report a Bug
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

This adds a form allowing users to submit questions to GitHub Discussions directly from the website. Key features include:
- New "Ask a Question" page with form to submit questions
- Form redirects to GitHub Discussions with pre-filled question
- Added under community navigation section
- Improved spacing and styling for better user experience

## What is the link to the Apache Jira?

https://issues.apache.org/jira/browse/HDDS-12613

## How was this patch tested?

Check off which of the following tests were done on this change. If additional testing was done, please elaborate here as well.

- [ ] The CI checks on my fork are passing
- [X] I verified the rendered content using a local preview
- [ ] I manually verified the steps provided in this change work as described
